### PR TITLE
Enabling forking in gom files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 gom
 vendor/**
+_vendor/**

--- a/gomfile_test.go
+++ b/gomfile_test.go
@@ -109,3 +109,22 @@ end
 		t.Fatalf("Expected %v, but %v:", expected, goms)
 	}
 }
+
+func TestGomfile5(t *testing.T) {
+	filename, err := tempGomfile(`
+gom 'github.com/mattn/gom', :fork => 'github.com/dicefm/gom'
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	goms, err := parseGomfile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := []Gom{
+		{name: "github.com/mattn/gom", options: map[string]interface{}{"fork": "github.com/dicefm/gom"}},
+	}
+	if !reflect.DeepEqual(goms, expected) {
+		t.Fatalf("Expected %v, but %v:", expected, goms)
+	}
+}

--- a/install.go
+++ b/install.go
@@ -102,30 +102,23 @@ func (gom *Gom) Clone(args []string) error {
 	if err != nil {
 		return err
 	}
+	name := getFork(gom)
 	if command, ok := gom.options["command"].(string); ok {
-		target, ok := gom.options["target"].(string)
-		if !ok {
-			target = gom.name
-		}
-
-		srcdir := filepath.Join(vendor, "src", target)
+		srcdir := filepath.Join(vendor, "src", name)
 		customCmd := strings.Split(command, " ")
 		customCmd = append(customCmd, srcdir)
 
-		fmt.Printf("fetching %s (%v)\n", gom.name, customCmd)
+		fmt.Printf("fetching %s (%v)\n", name, customCmd)
 		err = run(customCmd, Blue)
 		if err != nil {
 			return err
 		}
 	} else if private, ok := gom.options["private"].(string); ok {
 		if boolString[strings.ToLower(private)] {
-			target, ok := gom.options["target"].(string)
-			if !ok {
-				target = gom.name
-			}
-			srcdir := filepath.Join(vendor, "src", target)
+			srcdir := filepath.Join(vendor, "src", name)
 			if _, err := os.Stat(srcdir); err != nil {
 				if os.IsExist(err) {
+					fmt.Printf("pulling private %s\n", name)
 					if err := gom.pullPrivate(srcdir); err != nil {
 						return err
 					}
@@ -134,6 +127,7 @@ func (gom *Gom) Clone(args []string) error {
 					if possible, ok := gom.options["https"].(string); ok {
 						useHttps = boolString[strings.ToLower(possible)]
 					}
+					fmt.Printf("cloning private %s\n", name)
 					if err := gom.clonePrivate(srcdir, useHttps); err != nil {
 						return err
 					}
@@ -144,10 +138,30 @@ func (gom *Gom) Clone(args []string) error {
 
 	cmdArgs := []string{"go", "get", "-d"}
 	cmdArgs = append(cmdArgs, args...)
-	cmdArgs = append(cmdArgs, gom.name)
+	cmdArgs = append(cmdArgs, name)
 
-	fmt.Printf("downloading %s\n", gom.name)
-	return run(cmdArgs, Blue)
+	fmt.Printf("downloading %s\n", name)
+	result := run(cmdArgs, Blue)
+
+	// We're going to use a fork
+	if has(gom.options, "fork") {
+		// we now need to move from fork to target
+		var (
+			tag = getTarget(gom)
+			src = filepath.Join(vendor, "src", getFork(gom))
+			dst = filepath.Join(vendor, "src", tag)
+		)
+		fmt.Printf("forking (%s, %s)\n", name, tag)
+
+		if err := mustCopyDir(dst, src); err != nil {
+			return err
+		}
+		if err := os.RemoveAll(src); err != nil {
+			return err
+		}
+	}
+
+	return result
 }
 
 func (gom *Gom) pullPrivate(srcdir string) (err error) {
@@ -306,4 +320,19 @@ func install(args []string) error {
 	}
 
 	return nil
+}
+
+func getTarget(gom *Gom) string {
+	target, ok := gom.options["target"].(string)
+	if !ok {
+		target = gom.name
+	}
+	return target
+}
+
+func getFork(gom *Gom) string {
+	if has(gom.options, "fork") {
+		return gom.options["fork"].(string)
+	}
+	return getTarget(gom)
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// Use a wrapper to differentiate logged panics from unexpected ones.
+type LoggedError struct{ error }
+
+func panicOnError(err error, msg string) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Abort: %s: %s\n", msg, err)
+		panic(err)
+	}
+}
+
+func errorf(format string, args ...interface{}) {
+	// Ensure the user's command prompt starts on the next line.
+	if !strings.HasSuffix(format, "\n") {
+		format += "\n"
+	}
+	fmt.Fprintf(os.Stderr, format, args...)
+	panic(LoggedError{}) // Panic instead of os.Exit so that deferred will run.
+}
+
+func mustCopyFile(destFilename, srcFilename string) {
+	destFile, err := os.Create(destFilename)
+	panicOnError(err, "Failed to create file "+destFilename)
+
+	srcFile, err := os.Open(srcFilename)
+	panicOnError(err, "Failed to open file "+srcFilename)
+
+	_, err = io.Copy(destFile, srcFile)
+	panicOnError(err,
+		fmt.Sprintf("Failed to copy data from %s to %s", srcFile.Name(), destFile.Name()))
+
+	err = destFile.Close()
+	panicOnError(err, "Failed to close file "+destFile.Name())
+
+	err = srcFile.Close()
+	panicOnError(err, "Failed to close file "+srcFile.Name())
+}
+
+func mustChmod(filename string, mode os.FileMode) {
+	err := os.Chmod(filename, mode)
+	panicOnError(err, fmt.Sprintf("Failed to chmod %d %q", mode, filename))
+}
+
+// copyDir copies a directory tree over to a new directory.
+// Also, dot files and dot directories are skipped.
+func mustCopyDir(destDir, srcDir string) error {
+	var fullSrcDir string
+	// Handle symlinked directories.
+	f, err := os.Lstat(srcDir)
+	if err == nil && f.Mode()&os.ModeSymlink == os.ModeSymlink {
+		fullSrcDir, err = os.Readlink(srcDir)
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		fullSrcDir = srcDir
+	}
+
+	return filepath.Walk(fullSrcDir, func(srcPath string, info os.FileInfo, err error) error {
+		// Get the relative path from the source base, and the corresponding path in
+		// the dest directory.
+		relSrcPath := strings.TrimLeft(srcPath[len(fullSrcDir):], string(os.PathSeparator))
+		destPath := path.Join(destDir, relSrcPath)
+
+		// Create a subdirectory if necessary.
+		if info.IsDir() {
+			err := os.MkdirAll(path.Join(destDir, relSrcPath), 0777)
+			if !os.IsExist(err) {
+				panicOnError(err, "Failed to create directory")
+			}
+			return nil
+		}
+
+		// Else, just copy it over.
+		mustCopyFile(destPath, srcPath)
+		return nil
+	})
+}
+
+func exists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}
+
+// empty returns true if the given directory is empty.
+// the directory must exist.
+func empty(dirname string) bool {
+	dir, err := os.Open(dirname)
+	if err != nil {
+		errorf("error opening directory: %s", err)
+	}
+	defer dir.Close()
+	results, _ := dir.Readdir(1)
+	return len(results) == 0
+}


### PR DESCRIPTION
The idea is to enable a repo represent another repo. In the vien forking
allows a github repo to use a possible downstream fork.
- Make sure we move after go get

---

Example:

```
gom 'github.com/stripe/stripe-go', :fork => 'github.com/dicefm/stripe-go', :branch => 'dynamic-last-four'
```
